### PR TITLE
fix: normalize bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "homepage": "https://github.com/offline-ai/cli-plugin-cmd-test.js",
   "repository": "https://github.com/offline-ai/cli-plugin-cmd-test.js",
-  "bugs": "https://github.com/@offline-ai/cli-plugin-cmd-test.js/issues",
+  "bugs": {
+    "url": "https://github.com/offline-ai/cli-plugin-cmd-test.js/issues"
+  },
   "dependencies": {
     "@isdk/ai-test-runner": "workspace:*",
     "@isdk/ai-tool": "workspace:*",


### PR DESCRIPTION
## Summary
- normalize `bugs` metadata from a string to npm's standard `bugs.url` object
- fix the issue URL by removing the stray `@` from the GitHub path

This is metadata-only. It does not change runtime code, dependencies, package files, or build behavior.

## Verification
```sh
node -e "const p=require('./package.json'); if(p.name!=='@offline-ai/cli-plugin-cmd-test'||p.bugs?.url!=='https://github.com/offline-ai/cli-plugin-cmd-test.js/issues') process.exit(1); console.log('package metadata OK')"
npm pack --dry-run --ignore-scripts --json
git diff --check
```
